### PR TITLE
Have the k-e components assume the privs of the operator

### DIFF
--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -124,7 +124,14 @@ func (r *ReconcileInstall) install(instance *eventingv1alpha1.Install) error {
 	filters := []mf.FilterFn{mf.ByOwner(instance)}
 	switch {
 	case *olm:
-		filters = append(filters, mf.ByOLM, mf.ByNamespace(instance.GetNamespace()))
+		sa, err := k8sutil.GetOperatorName()
+		if err != nil {
+			return err
+		}
+		filters = append(filters,
+			mf.ByOLM,
+			mf.ByNamespace(instance.GetNamespace()),
+			mf.ByServiceAccount(sa))
 	case len(*namespace) > 0:
 		filters = append(filters, mf.ByNamespace(*namespace))
 	}


### PR DESCRIPTION
We can revisit later whether 'tis nobler to replicate the upstream RBAC in the CSV