### PR TITLE
Fix srvke 70

### DIFF
--- a/deploy/olm-catalog/knative-eventing-operator/0.5.0/knative-eventing-operator.v0.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-eventing-operator/0.5.0/knative-eventing-operator.v0.5.0.clusterserviceversion.yaml
@@ -239,6 +239,22 @@ spec:
         - apiGroups:
           - sources.eventing.knative.dev
           resources:
+          - awssqssources/finalizers
+          - containersources/finalizers
+          - cronjobsources/finalizers
+          - githubsources/finalizers
+          - kuberneteseventsources/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - sources.eventing.knative.dev
+          resources:
           - awssqssources/status
           - containersources/status
           - cronjobsources/status
@@ -597,7 +613,6 @@ spec:
     type: MultiNamespace
   - supported: true
     type: AllNamespaces
-  maturity: alpha
   keywords:
   - serverless
   - eventing
@@ -606,6 +621,7 @@ spec:
   maintainers:
   - email: mwessend@redhat.com
     name: Matthias Wessendorf
+  maturity: alpha
   provider:
     name: Knative Community
   replaces: knative-eventing.v0.4.1

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -250,6 +250,24 @@ rules:
       - patch
       - delete
 
+# Sources finalizer
+  - apiGroups:
+      - sources.eventing.knative.dev
+    resources:
+      - awssqssources/finalizers
+      - containersources/finalizers
+      - cronjobsources/finalizers
+      - githubsources/finalizers
+      - kuberneteseventsources/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
   # Source statuses update
   - apiGroups:
       - sources.eventing.knative.dev


### PR DESCRIPTION
we lacked the `*/finalers` for the sources (see SRVKE-70) in the `role.yaml`

based on that did regenerated the CSV  and the catalog is patched on the fork