### PR TITLE
Minor for consistency

### DIFF
--- a/deploy/olm-catalog/knative-eventing-operator/0.5.0/knative-eventing-operator.v0.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-eventing-operator/0.5.0/knative-eventing-operator.v0.5.0.clusterserviceversion.yaml
@@ -10,8 +10,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Knative Eventing Installation
-      displayName: Install Operator
+    - description: Represents an installation of a particular version of Knative Eventing
+      displayName: Knative Eventing
       kind: Install
       name: installs.eventing.knative.dev
       version: v1alpha1

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,6 +10,6 @@ eval VERSION=v$(grep Version version/version.go | awk '{print $3}')
 operator-sdk build quay.io/openshift-knative/$IMAGE:$VERSION
 docker push quay.io/openshift-knative/$IMAGE:$VERSION
 git tag -f $VERSION
-git push -f origin refs/tags/$VERSION:refs/tags/$VERSION
+git push --tags --force
 
 popd


### PR DESCRIPTION
Account for different remote names when tagging and make the
"Developer Catalog" look a little more sensible