### PR TITLE
Add knative eventing namespaced admin change

### DIFF
--- a/deploy/resources/knative-eventing-v0.7.0.yaml
+++ b/deploy/resources/knative-eventing-v0.7.0.yaml
@@ -287,6 +287,17 @@ rules:
   - watch
 
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["eventing.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Mirroring the changes in knative-serving-operator[1] this patch adds
knative-eventing-namespaced-admin role so that way admin users
can access knative eventing resources. This is helpful/important in
multi-tenant clusters, otherwise we have to add the rbac rule
manually.

[1] - https://github.com/openshift-knative/knative-serving-operator/pull/33