### PR TITLE
Removing the filter role, for the broker

### DIFF
--- a/pkg/controller/knativeeventing/knativeeventing_controller.go
+++ b/pkg/controller/knativeeventing/knativeeventing_controller.go
@@ -230,7 +230,6 @@ func addSCCforSpecialClusterRoles(u *unstructured.Unstructured) error {
 		"addressable-resolver",
 		"broker-addressable-resolver",
 		"channel-addressable-resolver",
-		"eventing-broker-filter",
 		"in-memory-channel-controller",
 		"in-memory-channel-dispatcher",
 		"knative-eventing-controller",


### PR DESCRIPTION
the `eventing-broker-ingress` was never part of this operator, and due to issue _SRVKE-112_ we are also removing the `-filter` counterpart of the broker related roles