### PR TITLE
removing NetworkPolicy override uRL

### DIFF
--- a/deploy/olm-catalog/knative-eventing-operator/0.12.0/knative-eventing-operator.v0.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/knative-eventing-operator/0.12.0/knative-eventing-operator.v0.12.0.clusterserviceversion.yaml
@@ -88,7 +88,7 @@ spec:
                   value: knative-eventing-operator
                 image: quay.io/openshift-knative/knative-eventing-operator:v0.12.0
                 args:
-                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.12.0/openshift/release/knative-eventing-v0.12.0.yaml,https://raw.githubusercontent.com/openshift-knative/knative-eventing-operator/v0.12.0/deploy/resources/networkpolicies.yaml
+                  - --filename=https://raw.githubusercontent.com/openshift/knative-eventing/release-v0.12.0/openshift/release/knative-eventing-v0.12.0.yaml
                 imagePullPolicy: Always
                 name: knative-eventing-operator
                 resources: {}


### PR DESCRIPTION
Since Serverless is now on Kourier / 1.5.0